### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Autodesk Fusion 360/AutodeskFusion360.pkg.recipe
+++ b/Autodesk Fusion 360/AutodeskFusion360.pkg.recipe
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload//%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/payload/Autodesk Fusion 360.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>

--- a/Dremel DigiLab 3D Slicer/DremelDigiLab3DSlicer.download.recipe
+++ b/Dremel DigiLab 3D Slicer/DremelDigiLab3DSlicer.download.recipe
@@ -60,7 +60,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/app/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/app/Dremel DigiLab 3D Slicer.app</string>
                 <key>requirement</key>
                 <string>identifier "com.eht3.slicer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JRH3BDU5ZX</string>
             </dict>

--- a/Dremel DigiLab 3D Slicer/DremelDigiLab3DSlicer.pkg.recipe
+++ b/Dremel DigiLab 3D Slicer/DremelDigiLab3DSlicer.pkg.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/app/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/app/Dremel DigiLab 3D Slicer.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleVersion</string>
             </dict>
@@ -46,9 +46,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/app/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/app/Dremel DigiLab 3D Slicer.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Dremel DigiLab 3D Slicer.app</string>
             </dict>
         </dict>
         <dict>

--- a/Express Scribe/ExpressScribe.download.recipe
+++ b/Express Scribe/ExpressScribe.download.recipe
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/dmg/%NAME%_i.dmg/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/dmg/%NAME%_i.dmg/ExpressScribe.app</string>
                 <key>requirement</key>
                 <string>identifier "com.nchsoftware.expressscribe" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7EH48C9K78"</string>
             </dict>

--- a/Restor/Restor.download.recipe
+++ b/Restor/Restor.download.recipe
@@ -45,7 +45,7 @@
         <key>Arguments</key>   
             <dict>   
                 <key>input_path</key>   
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Restor.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
             </dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.