### PR TITLE
Basic python3 compatibility

### DIFF
--- a/TestNav/SimpleJSONParser.py
+++ b/TestNav/SimpleJSONParser.py
@@ -21,9 +21,9 @@ import json
 from autopkglib import Processor, ProcessorError  # noqa: F401
 
 try:
-    from urllib import request as urllib  # For Python 3
+    from urllib.request import urlopen  # For Python 3
 except ImportError:
-    import urllib  # For Python 2
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["SimpleJSONParser"]
 
@@ -48,7 +48,7 @@ class SimpleJSONParser(Processor):
 
     def main(self):
         url = self.env.get("json_url")
-        response = urllib.urlopen(url)
+        response = urlopen(url)
         key = self.env.get("json_key")
         self.env["json_value"] = json.loads(response.read())[key]
         self.output("{}".format(self.env["json_value"]))

--- a/TestNav/SimpleJSONParser.py
+++ b/TestNav/SimpleJSONParser.py
@@ -15,10 +15,15 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import json
-import urllib
 
 from autopkglib import Processor, ProcessorError  # noqa: F401
+
+try:
+    from urllib import request as urllib  # For Python 3
+except ImportError:
+    import urllib  # For Python 2
 
 __all__ = ["SimpleJSONParser"]
 

--- a/TestNav/SimpleJSONParser.py
+++ b/TestNav/SimpleJSONParser.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import urllib
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.