### PR TITLE
Switch from CURL* back to URL* processors

### DIFF
--- a/GoPro Quik/GoProQuik.download.recipe
+++ b/GoPro Quik/GoProQuik.download.recipe
@@ -22,7 +22,7 @@
                 <string>quik.dmg</string>
             </dict>
             <key>Processor</key>
-            <string>CURLDownloader</string>
+            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Arguments</key>


### PR DESCRIPTION
As of [AutoPkg 0.6.0](https://github.com/autopkg/autopkg/tree/v0.6.0), it's safe to switch back to the "standard" URLDownloader and URLTextSearcher processors.