### PR TITLE
Use URLGetter for SimpleJSONParser processor

### DIFF
--- a/TestNav/SimpleJSONParser.py
+++ b/TestNav/SimpleJSONParser.py
@@ -18,39 +18,26 @@ from __future__ import absolute_import
 
 import json
 
-from autopkglib import Processor, ProcessorError  # noqa: F401
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter  # noqa: F401
 
 __all__ = ["SimpleJSONParser"]
 
 
-class SimpleJSONParser(Processor):
+class SimpleJSONParser(URLGetter):
     """Processor to output specified value of a JSON formatted file."""
 
     description = __doc__
     input_variables = {
-         "json_key": {
-            "required": True,
-            "descripton": "JSON key value to be parsed.",
-        },
-        "json_url": {
-            "required": True,
-            "description": "URL of the JSON to be parsed.",
-        },
+        "json_key": {"required": True, "descripton": "JSON key value to be parsed.",},
+        "json_url": {"required": True, "description": "URL of the JSON to be parsed.",},
     }
-    output_variables = {
-        "json_value": {"description": "JSON value from input key."}
-    }
+    output_variables = {"json_value": {"description": "JSON value from input key."}}
 
     def main(self):
         url = self.env.get("json_url")
-        response = urlopen(url)
+        response = self.download(url)
         key = self.env.get("json_key")
-        self.env["json_value"] = json.loads(response.read())[key]
+        self.env["json_value"] = json.loads(response)[key]
         self.output("{}".format(self.env["json_value"]))
 
 


### PR DESCRIPTION
This PR adjusts the SimpleJSONParser processor to use the new [URLGetter superclass](https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors), which will ease the transition to Python 3 and AutoPkg 2.

Here's a log of the adjusted processor in action, using the TestNav download recipe that references it:
https://gist.github.com/homebysix/294583c52e72ad3708ad06f1c948d626