### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Bitnami MAMP/BitnamiMAMP.pkg.recipe
+++ b/Bitnami MAMP/BitnamiMAMP.pkg.recipe
@@ -63,10 +63,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Lightspeed Relay/RelaySmartAgent.pkg.recipe
+++ b/Lightspeed Relay/RelaySmartAgent.pkg.recipe
@@ -85,10 +85,10 @@
             <dict>
                 <key>force_pkg_build</key>
                 <string>True</string>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>id</key>
                     <string>com.lightspeedsystems.mobilefilter</string>
                     <key>chown</key>

--- a/Lightspeed Relay/RelaySmartAgentKextless.pkg.recipe
+++ b/Lightspeed Relay/RelaySmartAgentKextless.pkg.recipe
@@ -96,10 +96,10 @@
             <dict>
                 <key>force_pkg_build</key>
                 <string>True</string>
-                <key>pkgname</key>
-                <string>%NAME%Kextless-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%Kextless-%version%</string>
                     <key>id</key>
                     <string>com.lightspeedsystems.mobilefilter</string>
                     <key>chown</key>

--- a/OpenWebStart/OpenWebStart.pkg.recipe
+++ b/OpenWebStart/OpenWebStart.pkg.recipe
@@ -56,10 +56,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Prey/Prey.pkg.recipe
+++ b/Prey/Prey.pkg.recipe
@@ -54,10 +54,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Scan Dimenson SOL/SOL.pkg.recipe
+++ b/Scan Dimenson SOL/SOL.pkg.recipe
@@ -60,10 +60,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).