### PR TITLE
Replace Versioner with PlistReader in GoogleDrive.pkg.recipe

### DIFF
--- a/Google Drive/GoogleDrive.pkg.recipe
+++ b/Google Drive/GoogleDrive.pkg.recipe
@@ -42,13 +42,18 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>input_plist_path</key>
+                <key>info_path</key>
                 <string>%RECIPE_CACHE_DIR%/payload/Google Drive.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleVersion</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleVersion</key>
+                    <string>version</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_version</string>
+                </dict>
             </dict>
             <key>Processor</key>
-            <string>Versioner</string>
+            <string>PlistReader</string>
         </dict>
         <dict>
             <key>Arguments</key>


### PR DESCRIPTION
Extracts both the version and the minimum macOS version needed to run from the Google Drive app.  This would be useful to include in downstream .jss and .munki recipes