### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Bean Loader/Bean Loader.pkg.recipe
+++ b/Bean Loader/Bean Loader.pkg.recipe
@@ -2,38 +2,36 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Comment</key>
-    <string>Created with Recipe Robot v1.0.4 (https://github.com/homebysix/recipe-robot)</string>
-    <key>Description</key>
-    <string>Downloads the latest version of Bean Loader and creates a package.</string>
-    <key>Identifier</key>
-    <string>com.github.nstrauss.pkg.BeanLoader</string>
-    <key>Input</key>
-    <dict>
-        <key>BUNDLE_ID</key>
-        <string>com.punchthrough.LightBlue-Bean.Bean-Loader</string>
-        <key>NAME</key>
-        <string>Bean Loader</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.6.1</string>
-    <key>ParentRecipe</key>
-    <string>com.github.nstrauss.download.BeanLoader</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>warning_message</key>
-                <string>Bean Loader has been discontinued. This recipe will eventually be removed. https://punchthrough.com/bean/</string>
-            </dict>
-            <key>Processor</key>
-            <string>DeprecationWarning</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>AppPkgCreator</string>
-        </dict>
-    </array>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.4 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of Bean Loader and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.nstrauss.pkg.BeanLoader</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Bean Loader</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.nstrauss.download.BeanLoader</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Bean Loader has been discontinued. This recipe will eventually be removed. https://punchthrough.com/bean/</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Bean Loader/Bean Loader.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/nstrauss-recipes/Bean\ Loader/Bean\ Loader.pkg.recipe
Processing repos/nstrauss-recipes/Bean Loader/Bean Loader.pkg.recipe...
DeprecationWarning
{'Input': {'warning_message': 'Bean Loader has been discontinued. This recipe '
                              'will eventually be removed. '
                              'https://punchthrough.com/bean/'}}
DeprecationWarning: Bean Loader has been discontinued. This recipe will eventually be removed. https://punchthrough.com/bean/
{'Output': {'deprecation_summary_result': {'data': {'name': 'Bean Loader.pkg',
                                                    'warning': 'Bean Loader '
                                                               'has been '
                                                               'discontinued. '
                                                               'This recipe '
                                                               'will '
                                                               'eventually be '
                                                               'removed. '
                                                               'https://punchthrough.com/bean/'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://punchthrough.com/files/bean/loader/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1672
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.12.6
SparkleUpdateInfoProvider: Found URL https://punchthrough.com/files/bean/loader/BeanLoader_1.12.6.dmg
{'Output': {'url': 'https://punchthrough.com/files/bean/loader/BeanLoader_1.12.6.dmg',
            'version': '1.12.6'}}
URLDownloader
{'Input': {'filename': 'Bean Loader-1.12.6.dmg',
           'url': 'https://punchthrough.com/files/bean/loader/BeanLoader_1.12.6.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/downloads/Bean Loader-1.12.6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/downloads/Bean '
                        'Loader-1.12.6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/downloads/Bean '
                         'Loader-1.12.6.dmg/Bean Loader.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.punchthrough.LightBlue-Bean.Bean-Loader" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'R5JUTH26F4)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/downloads/Bean Loader-1.12.6.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.QRJfhu/Bean Loader.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.QRJfhu/Bean Loader.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.QRJfhu/Bean Loader.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DeprecationWarning
{'Input': {'warning_message': 'Bean Loader has been discontinued. This recipe '
                              'will eventually be removed. '
                              'https://punchthrough.com/bean/'}}
DeprecationWarning: Bean Loader has been discontinued. This recipe will eventually be removed. https://punchthrough.com/bean/
{'Output': {'deprecation_summary_result': {'data': {'name': 'Bean Loader.pkg',
                                                    'warning': 'Bean Loader '
                                                               'has been '
                                                               'discontinued. '
                                                               'This recipe '
                                                               'will '
                                                               'eventually be '
                                                               'removed. '
                                                               'https://punchthrough.com/bean/'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
AppPkgCreator
{'Input': {'version': '1.12.6'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/downloads/Bean Loader-1.12.6.dmg
AppPkgCreator: Using path '/private/tmp/dmg.3AWudw/Bean Loader.app' matched from globbed '/private/tmp/dmg.3AWudw/*.app'.
AppPkgCreator: BundleID: com.punchthrough.LightBlue-Bean.Bean-Loader
AppPkgCreator: Copied /private/tmp/dmg.3AWudw/Bean Loader.app to ~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/payload/Applications/Bean Loader.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.punchthrough.LightBlue-Bean.Bean-Loader',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/Bean '
                                                                    'Loader-1.12.6.pkg',
                                                        'version': '1.12.6'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.12.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/receipts/Bean Loader.pkg-receipt-20210213-231001.plist

The following recipes have deprecation warnings:
    Name             Warning                                                                                                    
    ----             -------                                                                                                    
    Bean Loader.pkg  Bean Loader has been discontinued. This recipe will eventually be removed. https://punchthrough.com/bean/  
    Bean Loader.pkg  Bean Loader has been discontinued. This recipe will eventually be removed. https://punchthrough.com/bean/  

The following packages were built:
    Identifier                                   Version  Pkg Path                                                                                        
    ----------                                   -------  --------                                                                                        
    com.punchthrough.LightBlue-Bean.Bean-Loader  1.12.6   ~/Library/AutoPkg/Cache/com.github.nstrauss.pkg.BeanLoader/Bean Loader-1.12.6.pkg  
```

