### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/Anki/Anki.download.recipe
+++ b/Anki/Anki.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Anki</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Anki/Anki.pkg.recipe
+++ b/Anki/Anki.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Anki</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.Anki</string>

--- a/Audacity/Audacity.pkg.recipe
+++ b/Audacity/Audacity.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.rustymyers.download.Audacity</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Autodesk EAGLE/AutodeskEAGLE.download.recipe
+++ b/Autodesk EAGLE/AutodeskEAGLE.download.recipe
@@ -13,7 +13,7 @@
         <key>NAME</key>
         <string>AutodeskEAGLE</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Autodesk EAGLE/AutodeskEAGLE.pkg.recipe
+++ b/Autodesk EAGLE/AutodeskEAGLE.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.AutodeskEAGLE</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Bitnami MAMP/BitnamiMAMP.download.recipe
+++ b/Bitnami MAMP/BitnamiMAMP.download.recipe
@@ -15,7 +15,7 @@
         <key>RE_PATTERN</key>
         <string>href="(\/redirect\/to\/.*?.dmg)"</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Bitnami MAMP/BitnamiMAMP.pkg.recipe
+++ b/Bitnami MAMP/BitnamiMAMP.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>BitnamiMAMP</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.BitnamiMAMP</string>

--- a/CEmu/CEmu.download.recipe
+++ b/CEmu/CEmu.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>CEmu</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/CEmu/CEmu.pkg.recipe
+++ b/CEmu/CEmu.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.CEmu</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Camtasia/Camtasia.pkg.recipe
+++ b/Camtasia/Camtasia.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Camtasia</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.jps3.download.Camtasia</string>

--- a/Cricut Design Space/CricutDesignSpace.download.recipe
+++ b/Cricut Design Space/CricutDesignSpace.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>CricutDesignSpace</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Cricut Design Space/CricutDesignSpace.pkg.recipe
+++ b/Cricut Design Space/CricutDesignSpace.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>CricutDesignSpace</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.CricutDesignSpace</string>

--- a/Google Earth Pro/GoogleEarthPro.download.recipe
+++ b/Google Earth Pro/GoogleEarthPro.download.recipe
@@ -15,7 +15,7 @@
         <key>RE_PATTERN</key>
         <string>&lt;a href=&quot;(?P&lt;url&gt;https:\/\/.*\/googleearthpromac.*\.dmg)&quot;</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Google Earth Pro/GoogleEarthPro.pkg.recipe
+++ b/Google Earth Pro/GoogleEarthPro.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.GoogleEarthPro</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/HUE Intuition/HUEIntution.download.recipe
+++ b/HUE Intuition/HUEIntution.download.recipe
@@ -13,7 +13,7 @@
         <key>DOWNLOAD_URL</key>
         <string>https://files.huehd.com/downloads/HUEIntuitionMAC.zip</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/HUE Intuition/HUEIntution.pkg.recipe
+++ b/HUE Intuition/HUEIntution.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>HUE Intution</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.HUEIntuition</string>

--- a/Lego Mindstorms/LegoMindstormsEducationEV3Classroom.download.recipe
+++ b/Lego Mindstorms/LegoMindstormsEducationEV3Classroom.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_URL</key>
         <string>https://education.lego.com/en-us/downloads/mindstorms-ev3/software</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Lego Mindstorms/LegoMindstormsEducationEV3Classroom.pkg.recipe
+++ b/Lego Mindstorms/LegoMindstormsEducationEV3Classroom.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>EV3 Classroom</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.LegoMindstormsEducationEV3Classroom</string>

--- a/Lightspeed Relay/RelaySmartAgent.pkg.recipe
+++ b/Lightspeed Relay/RelaySmartAgent.pkg.recipe
@@ -12,7 +12,7 @@
         <key>NAME</key>
         <string>RelaySmartAgent</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Lightspeed Relay/RelaySmartAgentKextless.pkg.recipe
+++ b/Lightspeed Relay/RelaySmartAgentKextless.pkg.recipe
@@ -12,7 +12,7 @@
         <key>NAME</key>
         <string>RelaySmartAgent</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Loom/Loom.download.recipe
+++ b/Loom/Loom.download.recipe
@@ -13,7 +13,7 @@
         <key>SEARCH_URL</key>
         <string>https://www.loom.com/v1/desktop/download/mac</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Loom/Loom.pkg.recipe
+++ b/Loom/Loom.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Loom</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.Loom</string>

--- a/Minitab/Minitab.download.recipe
+++ b/Minitab/Minitab.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_URL</key>
         <string>https://www.minitab.com/en-us/downloads</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Mitel Connect/MitelConnect.download.recipe
+++ b/Mitel Connect/MitelConnect.download.recipe
@@ -13,7 +13,7 @@
         <key>NAME</key>
         <string>MitelConnect</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Mitel Connect/MitelConnect.pkg.recipe
+++ b/Mitel Connect/MitelConnect.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.MitelConnect</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/OBS/OBS.download.recipe
+++ b/OBS/OBS.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_URL</key>
         <string>https://obsproject.com/download</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/OBS/OBS.pkg.recipe
+++ b/OBS/OBS.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>OBS</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.OBS</string>

--- a/OpenWebStart/OpenWebStart.download.recipe
+++ b/OpenWebStart/OpenWebStart.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>OpenWebStart</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/OpenWebStart/OpenWebStart.pkg.recipe
+++ b/OpenWebStart/OpenWebStart.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.OpenWebStart</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/PLTW Kite Student Portal/PLTWKiteStudentPortal.pkg.recipe
+++ b/PLTW Kite Student Portal/PLTWKiteStudentPortal.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.PLTWKiteStudentPortal</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Prey/Prey.pkg.recipe
+++ b/Prey/Prey.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Prey</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.hansen-m.download.Prey</string>

--- a/Respondus LockDown Browser/RespondusLockDownBrowser.install.recipe
+++ b/Respondus LockDown Browser/RespondusLockDownBrowser.install.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.RespondusLockDownBrowser</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>Process</key>
     <array>

--- a/Respondus LockDown Browser/RespondusLockDownBrowser.pkg.recipe
+++ b/Respondus LockDown Browser/RespondusLockDownBrowser.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.install.RespondusLockDownBrowser</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>Process</key>
     <array>

--- a/Respondus LockDown Browser/RespondusLockDownBrowserLab.install.recipe
+++ b/Respondus LockDown Browser/RespondusLockDownBrowserLab.install.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.RespondusLockDownBrowserLab</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>Process</key>
     <array>

--- a/Respondus LockDown Browser/RespondusLockDownBrowserLab.pkg.recipe
+++ b/Respondus LockDown Browser/RespondusLockDownBrowserLab.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.install.RespondusLockDownBrowserLab</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0.0</string>
     <key>Process</key>
     <array>

--- a/Scan Dimenson SOL/SOL.download.recipe
+++ b/Scan Dimenson SOL/SOL.download.recipe
@@ -13,7 +13,7 @@
         <key>DOWNLOAD_URL</key>
         <string>https://public-gs.s3.amazonaws.com/software/scandimension/sol/SOL.dmg</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Scan Dimenson SOL/SOL.pkg.recipe
+++ b/Scan Dimenson SOL/SOL.pkg.recipe
@@ -13,7 +13,7 @@
         <key>version</key>
         <string>1.0</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.SOL</string>

--- a/Scratch 3/Scratch3.download.recipe
+++ b/Scratch 3/Scratch3.download.recipe
@@ -13,7 +13,7 @@
         <key>NAME</key>
         <string>Scratch 3</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Scratch 3/Scratch3.pkg.recipe
+++ b/Scratch 3/Scratch3.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
 	<string>com.github.nstrauss.download.Scratch3</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Splashtop/SlashtopBusiness.pkg.recipe
+++ b/Splashtop/SlashtopBusiness.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Splashtop Business</string> 
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.peetinc.download.SplashtopBusinessAccess</string>

--- a/Splashtop/SlashtopStreamer.pkg.recipe
+++ b/Splashtop/SlashtopStreamer.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Splashtop Streamer</string> 
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
 	<string>com.github.peetinc.download.SplashtopStreamer</string>

--- a/Splashtop/SplashtopSOS.download.recipe
+++ b/Splashtop/SplashtopSOS.download.recipe
@@ -13,7 +13,7 @@
         <key>DOWNLOAD_URL</key>
         <string>https://download.splashtop.com/sos/SplashtopSOS.dmg</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/The Pack/ThePack.download.recipe
+++ b/The Pack/ThePack.download.recipe
@@ -13,7 +13,7 @@
         <key>DOWNLOAD_URL</key>
         <string>https://nysci.org/wp-content/uploads/downloads/ThePack.dmg</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/The Pack/ThePack.pkg.recipe
+++ b/The Pack/ThePack.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>The Pack</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.ThePack</string>

--- a/Vendini Box Office/VendiniBoxOffice.pkg.recipe
+++ b/Vendini Box Office/VendiniBoxOffice.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.VendiniBoxOffice</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Vendini TicketAgent/VendiniTicketAgent.pkg.recipe
+++ b/Vendini TicketAgent/VendiniTicketAgent.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.download.VendiniTicketAgent</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>

--- a/Vernier/VernierGraphicalAnalysis.pkg.recipe
+++ b/Vernier/VernierGraphicalAnalysis.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>VernierGraphicalAnalysis</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.wardsparadox.download.vernier.graphicalanalysis</string>

--- a/Wacom/WacomTablet.pkg.recipe
+++ b/Wacom/WacomTablet.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>WacomTablet</string>
     </dict>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.rustymyers.download.WacomTablet</string>

--- a/jEdit/jEdit.pkg.recipe
+++ b/jEdit/jEdit.pkg.recipe
@@ -13,7 +13,7 @@
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.peshay.download.jEdit</string>
-    <key>MiniumumVersion</key>
+    <key>MinimumVersion</key>
     <string>1.0</string>
     <key>Process</key>
     <array>


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.