### PR TITLE
added DOWNLOAD_BUILD input variable

### DIFF
--- a/1Password/1Password.download.recipe
+++ b/1Password/1Password.download.recipe
@@ -9,14 +9,10 @@ DOWNLOAD_ARCH
 - "x86_64": x86_64 (default)
 - "aarch64": arm64
 
-DOWNLOAD_URL
-Alternatively, DOWNLOAD_URL input variable can be overridden to specify arch or a prerelease build.
-https://downloads.1password.com/mac/1Password-latest-x86_64.zip
-https://downloads.1password.com/mac/1Password-latest-aarch64.zip
-https://downloads.1password.com/mac/1Password-latest.NIGHTLY-x86_64.zip
-https://downloads.1password.com/mac/1Password-latest.NIGHTLY-aarch64.zip
-https://downloads.1password.com/mac/1Password-latest.BETA-x86_64.zip
-https://downloads.1password.com/mac/1Password-latest.BETA-aarch64.zip</string>
+DOWNLOAD_BUILD
+- "latest": production release (default)
+- "latest.BETA": beta release
+- "latest.NIGHTLY": nightly release</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.download.1Password</string>
     <key>Input</key>
@@ -25,8 +21,10 @@ https://downloads.1password.com/mac/1Password-latest.BETA-aarch64.zip</string>
         <string>1Password</string>
         <key>DOWNLOAD_ARCH</key>
         <string>x86_64</string>
+        <key>DOWNLOAD_BUILD</key>
+        <string>latest</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://downloads.1password.com/mac/1Password-latest-%DOWNLOAD_ARCH%.zip</string>
+        <string>https://downloads.1password.com/mac/1Password-%DOWNLOAD_BUILD%-%DOWNLOAD_ARCH%.zip</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.4</string>

--- a/1Password/1Password.pkg.recipe
+++ b/1Password/1Password.pkg.recipe
@@ -41,7 +41,7 @@
                 <key>app_path</key>
                 <string>%input_path%</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%DOWNLOAD_ARCH%-%version%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%DOWNLOAD_ARCH%-%version%-%DOWNLOAD_BUILD%.pkg</string>
             </dict>
             <key>Processor</key>
             <string>AppPkgCreator</string>

--- a/1Password/1Password.pkg.recipe
+++ b/1Password/1Password.pkg.recipe
@@ -41,7 +41,7 @@
                 <key>app_path</key>
                 <string>%input_path%</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%DOWNLOAD_ARCH%-%version%-%DOWNLOAD_BUILD%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%DOWNLOAD_BUILD%-%DOWNLOAD_ARCH%-%version%.pkg</string>
             </dict>
             <key>Processor</key>
             <string>AppPkgCreator</string>


### PR DESCRIPTION
- added `%DOWNLOAD_BUILD%` input variable (choose between latest, latest.BETA, or latest.nightly)
  - replaces `%DOWNLOAD_URL%` (but this input variable can still be set to avoid breaking existing recipe overrides)