### PR TITLE
Fix 1Password duplicate imports

### DIFF
--- a/1Password/1Password.munki.recipe
+++ b/1Password/1Password.munki.recipe
@@ -92,13 +92,36 @@ exit 0
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>input_plist_path</key>
+                <string>%input_path%/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>dmg_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%ARCHITECTURE%.dmg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%ARCHITECTURE%-%version%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>DmgCreator</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
         </dict>
         <dict>
             <key>Arguments</key>

--- a/1Password/1Password.pkg.recipe
+++ b/1Password/1Password.pkg.recipe
@@ -22,6 +22,8 @@
             <dict>
                 <key>input_plist_path</key>
                 <string>%input_path%/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleVersion</string>
             </dict>
             <key>Processor</key>
             <string>Versioner</string>


### PR DESCRIPTION
https://macadmins.slack.com/archives/C056155B4/p1661459373289909

On every Munki recipe run 1Password being imported as new. `MunkiImporter` failed to find a matching item. After debugging found `%version%` and pkginfo's `version` didn't match. This uses `CFBundleVersion` which is the most complete version string available in Info.plist as of writing. 