### PR TITLE
1Password Munki recipe improvements

### DIFF
--- a/1Password/1Password.munki.recipe
+++ b/1Password/1Password.munki.recipe
@@ -68,6 +68,7 @@ if [[ ! -z "$user_id" ]]; then
     done
 fi
 
+/usr/bin/killall "1Password"
 /usr/bin/killall "1Password 7"
 
 exit 0

--- a/1Password/1Password.munki.recipe
+++ b/1Password/1Password.munki.recipe
@@ -74,7 +74,7 @@ fi
 exit 0
             </string>
             <key>unattended_install</key>
-            <true/>
+            <false/>
             <key>unattended_uninstall</key>
             <true/>
         </dict>

--- a/1Password/1Password.munki.recipe
+++ b/1Password/1Password.munki.recipe
@@ -21,11 +21,6 @@ Use either x86_64 or arm64 for ARCHITECTURE key.
         <string>1Password</string>
         <key>pkginfo</key>
         <dict>
-            <key>blocking_applications</key>
-            <array>
-                <string>1Password</string>
-                <string>1Password 7</string>
-            </array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>


### PR DESCRIPTION
- Remove blocking apps
- Kill `1Password` and `1Password 7` apps
- Make this an attended install