### PR TITLE
Wireshark recipes

### DIFF
--- a/Wireshark/Wireshark.download.recipe
+++ b/Wireshark/Wireshark.download.recipe
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Wireshark.
+
+ARCHITECTURE key values:
+x86_64: "intel"
+arm64: "arm"
+    </string>
+    <key>Identifier</key>
+    <string>com.github.nstrauss.download.Wireshark</string>
+    <key>Input</key>
+    <dict>
+        <key>WIRESHARK_ARCH</key>
+        <string>intel</string>
+        <key>NAME</key>
+        <string>Wireshark</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://www.wireshark.org/download.html</string>
+                <key>re_pattern</key>
+                <string>href=&quot;(?P&lt;download_url&gt;https:\/\/[^&quot;]*%WIRESHARK_ARCH%[^&quot;]*.dmg)&quot;</string>
+                <key>re_flags</key>
+                <array>
+                    <string>IGNORECASE</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%download_url%</string>
+                <key>filename</key>
+                <string>%NAME%-%WIRESHARK_ARCH%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Wireshark.app</string>
+                <key>requirement</key>
+                <string>identifier "org.wireshark.Wireshark" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7Z6EMTD2C6"</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Wireshark/Wireshark.munki.recipe
+++ b/Wireshark/Wireshark.munki.recipe
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads Wireshark and imports into Munki.
+
+Note: The default supported_architectures key is x86_64. Change this in an override for arm64.
+    </string>
+    <key>Identifier</key>
+    <string>com.github.nstrauss.munki.Wireshark</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/wireshark</string>
+        <key>NAME</key>
+        <string>Wireshark</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Wireshark is a free and open-source packet analyzer. It is used for network troubleshooting, analysis, and software.</string>
+            <key>category</key>
+            <string>Network Utilities</string>
+            <key>developer</key>
+            <string>Wireshark Foundation</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>x86_64</string>
+            </array>
+            <key>unattended_install</key>
+            <true/>
+            <key>unattended_uninstall</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>ParentRecipe</key>
+    <string>com.github.nstrauss.download.Wireshark</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%pathname%/Wireshark.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_version</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>munkiimport_appname</key>
+                <string>Wireshark.app</string>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Wireshark/Wireshark.pkg.recipe
+++ b/Wireshark/Wireshark.pkg.recipe
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads Wireshark and creates a package.</string>
+    <key>Identifier</key>
+    <string>com.github.nstrauss.pkg.Wireshark</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Wireshark</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.nstrauss.download.Wireshark</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%pathname%/Wireshark.app/Contents/Info.plist</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/Wireshark-%WIRESHARK_ARCH%-%version%.pkg</string>
+            </dict>
+            <key>Processor</key>
+            <string>AppPkgCreator</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Forked from https://github.com/autopkg/jleggat-recipes/tree/master/Wireshark I probably should have opened a PR there, but the changes were significant enough I figured the community could benefit from two different approaches. 

- Uses DMG for munkiimport
- Moves versioner to pkg recipe
- Supports multiple arch regex