### PR TITLE
add processor architecture choice variable, because exacqVision provides both …

### DIFF
--- a/exacqVision/exacqVision.download.recipe
+++ b/exacqVision/exacqVision.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of exacqVision Client.</string>
+    <string>Downloads the latest version of exacqVision Client.
+Specify arm64 or x86 for ARCHITECTURE, defaults to arm64 because we are living in the future 
+    </string>
     <key>Identifier</key>
     <string>com.github.nstrauss.download.exacqVision</string>
     <key>Input</key>
@@ -14,6 +16,8 @@
         <string>https://www.exacq.com/support/downloads.php</string>
         <key>DOWNLOAD_URL</key>
         <string>https://exacq.com/public</string>
+		<key>ARCHITECTURE</key>
+		<string>arm64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
@@ -51,9 +55,9 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%DOWNLOAD_URL%/%MAIN_VERSION%/exacqVisionClient_%version%_x64.dmg</string>
+                <string>%DOWNLOAD_URL%/%MAIN_VERSION%/exacqVisionClient_%version%_%ARCHITECTURE%.dmg</string>
                 <key>filename</key>
-                <string>exacqVisionClient_%version%_x64.dmg</string>
+                <string>exacqVisionClient_%version%_%ARCHITECTURE%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/exacqVision/exacqVision.download.recipe
+++ b/exacqVision/exacqVision.download.recipe
@@ -4,7 +4,7 @@
 <dict>
     <key>Description</key>
     <string>Downloads the latest version of exacqVision Client.
-Specify arm64 or x86 for ARCHITECTURE, defaults to arm64 because we are living in the future 
+Use arm64 or x86 for ARCHITECTURE.
     </string>
     <key>Identifier</key>
     <string>com.github.nstrauss.download.exacqVision</string>
@@ -16,8 +16,8 @@ Specify arm64 or x86 for ARCHITECTURE, defaults to arm64 because we are living i
         <string>https://www.exacq.com/support/downloads.php</string>
         <key>DOWNLOAD_URL</key>
         <string>https://exacq.com/public</string>
-		<key>ARCHITECTURE</key>
-		<string>arm64</string>
+        <key>ARCHITECTURE</key>
+        <string>arm64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>


### PR DESCRIPTION
…an arm64 and a x86 specific downloads

The exacqVision website now offers processor specific versions of their client software https://exacq.com/support/downloads.php

Hopefully exacq will make a universal binary, but until then, specifying the architecture type as a variable allows your code to be used for both processor types, eg. -
https://exacq.com/public/23.03/exacqVisionClient_23.03.1.0_x64.dmg
https://exacq.com/public/23.03/exacqVisionClient_23.03.1.0_arm64.dmg