### PR TITLE
Ensure Okta Verify uninstall succeeds even if no receipt is present

### DIFF
--- a/Okta Verify/OktaVerify.munki.recipe
+++ b/Okta Verify/OktaVerify.munki.recipe
@@ -41,6 +41,7 @@
 /usr/bin/killall "Okta Verify"
 /bin/rm -rf "/Applications/Okta Verify.app"
 pkgutil --forget com.okta.mobile
+exit 0
             </string>
         </dict>
     </dict>


### PR DESCRIPTION
This PR adds `exit 0` at the end of the Okta Verify uninstall script. Without this, the script will exit nonzero if no Okta receipt is found in the `pktuil --forget` command, which is undesirable.