### PR TITLE
Cleaning OktaVerify cache after each run

### DIFF
--- a/Okta Verify/OktaVerify.munki.recipe
+++ b/Okta Verify/OktaVerify.munki.recipe
@@ -79,6 +79,15 @@ exit 0
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <string>%RECIPE_CACHE_DIR%/payload/Applications/Okta Verify.app</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
We occasionally see autopkg fails due to permissions issues overwriting the `OktaVerify.app` file left in the cache from previous runs. This PR adds a step to delete the unpackaged app after each run to avoid this issue.