### PR TITLE
OBS change ARCH value to match new values

### DIFF
--- a/OBS/OBS.download.recipe
+++ b/OBS/OBS.download.recipe
@@ -4,7 +4,7 @@
 <dict>
     <key>Description</key>
     <string>Download the latest OBS disk image.
-    For ARCH use "x86_64" for Intel or "arm64" for ARM</string>
+    For ARCH use "Intel" for Intel/x86_64 or "Apple" for ARM/arm64</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.download.OBS</string>
     <key>Input</key>
@@ -12,7 +12,7 @@
         <key>NAME</key>
         <string>OBS</string>
         <key>ARCH</key>
-        <string>x86_64</string>        
+        <string>Intel</string>        
         <key>RE_PATTERN</key>
         <string>href="(.*?%ARCH%.dmg)"</string>
         <key>SEARCH_URL</key>

--- a/OBS/OBS.pkg.recipe
+++ b/OBS/OBS.pkg.recipe
@@ -4,7 +4,7 @@
 <dict>
     <key>Description</key>
     <string>Download the latest OBS disk image and builds a package.
-    For ARCH use "x86_64" for Intel or "arm64" for ARM</string>
+    For ARCH use "Intel" for Intel/x86_64 or "Apple" for ARM/arm64</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.pkg.OBS</string>
     <key>Input</key>
@@ -12,7 +12,7 @@
         <key>NAME</key>
         <string>OBS</string>
         <key>ARCH</key>
-        <string>x86_64</string>
+        <string>Intel</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0</string>


### PR DESCRIPTION
The new OBS files have different values for the architecture in the file name. It is now Intel or Apple