### PR TITLE
Update OktaVerify.munki.recipe

### DIFF
--- a/Okta Verify/OktaVerify.munki.recipe
+++ b/Okta Verify/OktaVerify.munki.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download Okta Verify, copy to versioned package, and import into Munki.</string>
+    <string>Download Okta Verify, copy to versioned package, and import into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.munki.OktaVerify</string>
     <key>Input</key>
@@ -14,6 +16,8 @@
         <string>Security</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/OktaVerify</string>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -46,7 +50,7 @@ exit 0
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.nstrauss.pkg.OktaVerify</string>
     <key>Process</key>
@@ -56,6 +60,8 @@ exit 0
             <dict>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
                 <key>installs_item_paths</key>
                 <array>
                     <string>/Applications/Okta Verify.app</string>


### PR DESCRIPTION
Hi, @nstrauss 

The Okta Verify Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 12.0

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v OktaVerify.munki.recipe
Looking for com.github.nstrauss.pkg.OktaVerify...
Did not find com.github.nstrauss.pkg.OktaVerify in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.nstrauss.pkg.OktaVerify...
Found com.github.nstrauss.pkg.OktaVerify in recipe map
Looking for com.github.nstrauss.download.OktaVerify...
Found com.github.nstrauss.download.OktaVerify in recipe map
**load_recipe time: 0.006908082985319197
Processing OktaVerify.munki.recipe...
WARNING: OktaVerify.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 02 Apr 2024 18:09:57 GMT
URLDownloader: Storing new ETag header: "******************"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/downloads/OktaVerify.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "OktaVerify.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-03-22 23:31:33 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Okta, Inc. (B7F62B65BN)
CodeSignatureVerifier:        Expires: 2025-09-04 18:23:12 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            3C 7B 21 EC 54 9C A3 9B EB 1F CC DD 4C 86 3B 89 1A 16 F7 02 A6 F0 
CodeSignatureVerifier:            0F FE C2 E4 4E 6B 7C 9C 60 DE
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/downloads/OktaVerify.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/unpack/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/payload/Applications
Versioner
Versioner: Found version 9.13.4 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/payload/Applications/Okta Verify.app/Contents/Info.plist
PlistReader
PlistReader: Reading: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/payload/Applications/Okta Verify.app/Contents/Info.plist
PlistReader: Assigning value of '2024.322.2325' to output variable 'ov_build'
PkgCopier
PkgCopier: Copied /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/downloads/OktaVerify.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/OktaVerify-9.13.4.2024.322.2325.pkg
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Okta Verify.app
MunkiInstallsItemsCreator: Derived minimum os version as: 12.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.okta.mobile', 'CFBundleName': 'Okta Verify', 'CFBundleShortVersionString': '9.13.4', 'CFBundleVersion': '2024.322.2325', 'minosversion': '12.0', 'path': '/Applications/Okta Verify.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '12.0'} into pkginfo
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '9.13.4.2024.322.2325'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/OktaVerify/OktaVerify-9.13.4.2024.322.2325.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/OktaVerify/OktaVerify-9.13.4.2024.322.2325.pkg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/receipts/OktaVerify.munki-receipt-20240417-150205.plist

The following new items were downloaded:
    Download Path                                                                                           
    -------------                                                                                           
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/downloads/OktaVerify.pkg  

The following packages were copied:
    Pkg Path                                                                                                           
    --------                                                                                                           
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.nstrauss.munki.OktaVerify/OktaVerify-9.13.4.2024.322.2325.pkg  

The following new items were imported into Munki:
    Name        Version               Catalogs  Pkginfo Path                                           Pkg Repo Path                                        Icon Repo Path  
    ----        -------               --------  ------------                                           -------------                                        --------------  
    OktaVerify  9.13.4.2024.322.2325  testing   apps/OktaVerify/OktaVerify-9.13.4.2024.322.2325.plist  apps/OktaVerify/OktaVerify-9.13.4.2024.322.2325.pkg
```
