### PR TITLE
VirusTotalReporter: Coerce summary results to string

### DIFF
--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -234,8 +234,8 @@ class VirusTotalReporter(Processor):
         malicious = last_analysis_stats.get("malicious", 0)
         suspicious = last_analysis_stats.get("suspicious", 0)
         undetected = last_analysis_stats.get("undetected", 0)
-        total_detected = str(harmless + malicious + suspicious)
-        total = str(harmless + malicious + suspicious + undetected)
+        total_detected = harmless + malicious + suspicious
+        total = harmless + malicious + suspicious + undetected
 
         self.env["virus_total_analyzer_summary_result"] = {
             "summary_text": "The following items were queried from the VirusTotal database:",
@@ -247,11 +247,11 @@ class VirusTotalReporter(Processor):
             ],
             "data": {
                 "name": os.path.basename(input_path),
-                "detections": total_detected,
-                "harmless": harmless,
-                "malicious": malicious,
-                "suspicious": suspicious,
-                "undetected": undetected,
+                "detections": str(total_detected),
+                "harmless": str(harmless),
+                "malicious": str(malicious),
+                "suspicious": str(suspicious),
+                "undetected": str(undetected),
                 "ratio": f"{total_detected}/{total}",
                 "permalink": f"https://www.virustotal.com/gui/file/{sha256}",
             },


### PR DESCRIPTION
AutoPkg pretty much assumes everything will always be a string. Otherwise it gets angry. Coerce summary results to string, which can be modified as needed later in whatever post-processing is done. Previously results were mixed string and integer anyway, which didn't make sense.

```python
The following items were queried from the VirusTotal database:
Traceback (most recent call last):
  File "/usr/local/bin/autopkg", line 2786, in <module>
    sys.exit(main(sys.argv))
  File "/usr/local/bin/autopkg", line 2782, in main
    return subcommands[verb]["function"](argv)
  File "/usr/local/bin/autopkg", line 2391, in run_recipes
    this_column = [len(row[column]) for row in rows]
  File "/usr/local/bin/autopkg", line 2391, in <listcomp>
    this_column = [len(row[column]) for row in rows]
TypeError: object of type 'int' has no len()
```
https://github.com/autopkg/autopkg/blob/8a12727820da6be40ee27530ac492c30283e54ca/Code/autopkg#L2388-L2392