### PR TITLE
VirusTotalReporter: Implement URL analysis fallback support

### DIFF
--- a/VirusTotalReporter/README.md
+++ b/VirusTotalReporter/README.md
@@ -33,7 +33,7 @@ By default, `VirusTotalReporter` does not submit new files for analysis. If ther
 1. Including analysis only for already submitted files could mean a sizable coverage gap. In workflows where trust and import/upload decisions are made based on VirusTotal detections, files which have never been analyzed are assumed safe, even when they may not be.
 1. The VirusTotal [license](https://docs.virustotal.com/reference/public-vs-premium-api) requires businesses using the free, public API to contribute new files.
 
-In order to submit new files, set `VIRUSTOTAL_SUBMIT_NEW` to true. On submission, `VirusTotalReporter` will check every 30 seconds whether file analysis has completed and then return detection results in the same run. Timeout length is 5 minutes and can be configured with `submission_timeout`. The max file size limit is 650 MB.
+In order to submit new files, set `VIRUSTOTAL_SUBMIT_NEW` to true. On submission, `VirusTotalReporter` will check every 30 seconds whether file analysis has completed and then return detection results in the same run. Timeout length is 5 minutes and can be configured with `submission_timeout`. The max file size limit is 650 MB. When a file is over the limit, analysis of the download URL will be used instead if available. URL analysis fallback behavior is on by default, and can be configured by setting `url_analysis_fallback`. The key `analysis_type` in summary results returns either "file" or "url" depending on the analysis used.
 
 ## VirusTotal API keys
 A community API key is included. To use your own key, follow the [getting started](https://docs.virustotal.com/reference/getting-started) guide to register an account. `VIRUSTOTAL_API_KEY` can be set to use the account specific key.

--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -234,7 +234,7 @@ class VirusTotalReporter(Processor):
         malicious = last_analysis_stats.get("malicious", 0)
         suspicious = last_analysis_stats.get("suspicious", 0)
         undetected = last_analysis_stats.get("undetected", 0)
-        total_detected = harmless + malicious + suspicious
+        total_detected = malicious + suspicious
         total = harmless + malicious + suspicious + undetected
 
         self.env["virus_total_analyzer_summary_result"] = {

--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -330,7 +330,7 @@ class VirusTotalReporter(Processor):
                 self.output(
                     "WARNING: File size is over 650 MB. Too large to submit to VirusTotal for analysis."
                 )
-                if self.env.get("url_analysis_fallback") and self.env.get("url"):
+                if self.env.get("url_analysis_fallback") is True and self.env.get("url"):
                     self.output(
                         "Falling back to get analysis report from download URL instead."
                     )
@@ -340,7 +340,8 @@ class VirusTotalReporter(Processor):
                     self.process_summary_results(report, input_path)
                     return
                 self.output(
-                    "No download URL input variable found as an alternative. Skipping."
+                    "No download URL input variable found or "
+                    "URL analysis fallback is not configured. Skipping."
                 )
                 return
 


### PR DESCRIPTION
- No longer count harmless detections as counting against the total score. VirusTotal doesn't. We shouldn't either.
- Attempt to use URL analysis in cases where the max file size exceeds 650 MB for new submissions.  See README changes for more details.