### PR TITLE
VirusTotalReporter: Improve URL analysis report checking

### DIFF
--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -335,8 +335,8 @@ class VirusTotalReporter(Processor):
                         "Falling back to get analysis report from download URL instead."
                     )
                     url_identifier = self.get_base64_unpadded(self.env["url"])
-
                     report, report_status_code = self.virustotal_api_v3(f"/urls/{url_identifier}")
+
                     if report_status_code == 200:
                         self.process_summary_results(report, input_path)
                         return

--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -335,6 +335,12 @@ class VirusTotalReporter(Processor):
                         "Falling back to get analysis report from download URL instead."
                     )
                     url_identifier = self.get_base64_unpadded(self.env["url"])
+
+                    report, report_status_code = self.virustotal_api_v3(f"/urls/{url_identifier}")
+                    if report_status_code == 200:
+                        self.process_summary_results(report, input_path)
+                        return
+
                     self.submit_new(self.env.get("url"), url_identifier, "url")
                     report, _ = self.virustotal_api_v3(f"/urls/{url_identifier}")
                     self.process_summary_results(report, input_path)

--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -335,7 +335,9 @@ class VirusTotalReporter(Processor):
                         "Falling back to get analysis report from download URL instead."
                     )
                     url_identifier = self.get_base64_unpadded(self.env["url"])
-                    report, report_status_code = self.virustotal_api_v3(f"/urls/{url_identifier}")
+                    report, report_status_code = self.virustotal_api_v3(
+                        f"/urls/{url_identifier}"
+                    )
 
                     if report_status_code == 200:
                         self.process_summary_results(report, input_path)


### PR DESCRIPTION
When falling back to URL analysis, check for an existing report first like with files. Otherwise URLs were always been submitted for analysis. Faster to get a response and decreases the chance of getting rate limited.