### PR TITLE
update homebrew installer signature

### DIFF
--- a/Homebrew/Homebrew.download.recipe.yaml
+++ b/Homebrew/Homebrew.download.recipe.yaml
@@ -19,6 +19,6 @@ Process:
     Arguments:
       input_path: "%pathname%"
       expected_authority_names: 
-        - "Developer ID Installer: Mike McQuaid (6248TWFRH6)"
+        - "Developer ID Installer: Patrick Linnane (927JGANW46)"
         - Developer ID Certification Authority
         - Apple Root CA


### PR DESCRIPTION
The Apple Developer account signing the Homebrew installer switched with 4.3.9 from @MikeMcQuaid to @p-linnane as discussed https://macadmins.slack.com/archives/C10EVE8TS/p1720511467448949.