### PR TITLE
Update VirusTotalReporter.py

### DIFF
--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -87,7 +87,7 @@ class VirusTotalReporter(Processor):
             "description": "Output the full VirusTotal report to the recipe result plist.",
         },
         "json_report_path": {
-            "default": None,
+            "default": "",
             "required": False,
             "description": "Write the full VirusTotal report to JSON at the configured path.",
         },


### PR DESCRIPTION
As per the discussion in the macadmins slack - https://macadmins.slack.com/archives/C056UTQ3M/p1723836902392129

This PR changes `json_report_path`'s default value from `None` to `""`.

Prior to this PR, I was seeing the running the below:

```
>>> import plistlib
>>> import subprocess
>>> cmd_args = ['/usr/local/autopkg/python', '/Users/ben.toms/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes/VirusTotalReporter/VirusTotalReporter.py', '<', '/Users/ben.toms/Library/AutoPkg/Cache/com.github.autopkg.download.VLC/downloads/VLC-3.0.21.plist']
>>> temp_env = {'PYTHONPATH': '/Library/AutoPkg'}                                                                                                                               
>>> plist_content = {'VIRUSTOTAL_ALWAYS_REPORT': True, 'VIRUSTOTAL_SUBMIT_NEW': True}
>>> plist_var = plistlib.dumps(plist_content)
>>> cmd_args = ['/usr/local/autopkg/python', '/Users/ben.toms/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes/VirusTotalReporter/VirusTotalReporter.py', plist_var]
>>> subprocess.run(cmd_args, env=temp_env)
```

Would error with:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>&lt;?xml version</key>
	<string>"1.0" encoding="UTF-8"?&gt;
&lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
&lt;plist version="1.0"&gt;
&lt;dict&gt;
	&lt;key&gt;VIRUSTOTAL_ALWAYS_REPORT&lt;/key&gt;
	&lt;true/&gt;
	&lt;key&gt;VIRUSTOTAL_SUBMIT_NEW&lt;/key&gt;
	&lt;false/&gt;
&lt;/dict&gt;
&lt;/plist&gt;
</string>
	<key>VIRUSTOTAL_ALWAYS_REPORT</key>
	<false/>
	<key>VIRUSTOTAL_API_KEY</key>
	<string>3858a94a911f47707717f6d090dbb8f86badb750b0f7bfe74a55c0c6143e3de6</string>
	<key>VIRUSTOTAL_SKIP</key>
	<false/>
	<key>VIRUSTOTAL_SUBMIT_NEW</key>
	<false/>
	<key>json_report_path</key>
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 589, in write_output_plist
    with open(self.outfile, "wb") as f:
TypeError: expected str, bytes or os.PathLike object, not TextIOWrapper

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ben.toms/Git/other/nstrauss-recipes/VirusTotalReporter/VirusTotalReporter.py", line 375, in <module>
    PROCESSOR.execute_shell()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 659, in execute_shell
    self.write_output_plist()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 592, in write_output_plist
    plistlib.dump(self.env, self.outfile.buffer)
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/plistlib.py", line 894, in dump
    writer.write(value)
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/plistlib.py", line 325, in write
    self.write_value(value)
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/plistlib.py", line 348, in write_value
    self.write_dict(value)
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/plistlib.py", line 389, in write_dict
    self.write_value(value)
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/plistlib.py", line 360, in write_value
    raise TypeError("unsupported type: %s" % type(value))
TypeError: unsupported type: <class 'NoneType'>
```

But after this change, things proceed as expected:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>&lt;?xml version</key>
	<string>"1.0" encoding="UTF-8"?&gt;
&lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
&lt;plist version="1.0"&gt;
&lt;dict&gt;
	&lt;key&gt;VIRUSTOTAL_ALWAYS_REPORT&lt;/key&gt;
	&lt;true/&gt;
	&lt;key&gt;VIRUSTOTAL_SUBMIT_NEW&lt;/key&gt;
	&lt;false/&gt;
&lt;/dict&gt;
&lt;/plist&gt;
</string>
	<key>VIRUSTOTAL_ALWAYS_REPORT</key>
	<false/>
	<key>VIRUSTOTAL_API_KEY</key>
	<string>3858a94a911f47707717f6d090dbb8f86badb750b0f7bfe74a55c0c6143e3de6</string>
	<key>VIRUSTOTAL_SKIP</key>
	<false/>
	<key>VIRUSTOTAL_SUBMIT_NEW</key>
	<false/>
	<key>json_report_path</key>
	<string></string>
	<key>output_full_report</key>
	<false/>
	<key>submission_timeout</key>
	<integer>300</integer>
	<key>url_analysis_fallback</key>
	<true/>
</dict>
</plist>
```

I also attempted to fix this in a PR to Autopkg as well - https://github.com/autopkg/autopkg/commit/667534362be1ff92322d6ae625466feb051931c2
