### PR TITLE
Ensure submission_timeout is an int

### DIFF
--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -205,7 +205,7 @@ class VirusTotalReporter(Processor):
         while True:
             time.sleep(30)
             timer += 30
-            if timer > self.env.get("submission_timeout"):
+            if timer > int(self.env.get("submission_timeout")):
                 raise ProcessorError(
                     f"New {type} submission timed out waiting for analysis to complete. "
                     f"Check report status at https://www.virustotal.com/gui/{type}/{identifier}"


### PR DESCRIPTION
When supplying `submission_timeout` via the CLI (for example with `--key submission_timeout=450`), a type error is thrown because the CLI input is read as a string and then compared to an integer:

```
Error in local.download.FooBar: Processor: com.github.nstrauss.VirusTotalReporter/VirusTotalReporter: Error: '>' not supported between instances of 'int' and 'str'
```
This PR fixes that problem.