### PR TITLE
Update CEmu.download.recipe

### DIFF
--- a/CEmu/CEmu.download.recipe
+++ b/CEmu/CEmu.download.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>NAME</key>
         <string>CEmu</string>
+        <key>GITHUB_ARCHITECTURE</key>
+        <string>arm</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0</string>
@@ -23,7 +25,7 @@
                 <key>include_prereleases</key>
                 <string>false</string>
                 <key>asset_regex</key>
-                <string>^.*(macOS).*$</string>
+                <string>^.*(macOS_Qt6_%GITHUB_ARCHITECTURE%).*$</string>
             </dict>
             <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
@@ -32,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>CEmu-%version%.dmg</string>
+                <string>CEmu-%GITHUB_ARCHITECTURE%-%version%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -47,7 +49,7 @@
                 <key>input_path</key>
                 <string>%pathname%/CEmu.app</string>
                 <key>requirement</key>
-                <string>identifier "com.adriweb.CEmu" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z3B7V95FNU</string>
+                <string>identifier "com.yourcompany.CEmu" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z3B7V95FNU</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>

--- a/CEmu/CEmu.download.recipe
+++ b/CEmu/CEmu.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest release of CEmu from GitHub.</string>
+    <string>Downloads the latest release of CEmu from GitHub. GITHUB_ARCHITECTURE can be either 'arm' or 'intel'.</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.download.CEmu</string>
     <key>Input</key>

--- a/CEmu/CEmu.pkg.recipe
+++ b/CEmu/CEmu.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest release of CEmu from GitHub and builds a package.</string>
+    <string>Downloads the latest release of CEmu from GitHub and builds a package. GITHUB_ARCHITECTURE can be either 'arm' or 'intel'.</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.pkg.CEmu</string>
     <key>Input</key>
@@ -20,6 +20,11 @@
         <dict>
             <key>Processor</key>
             <string>AppPkgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%GITHUB_ARCHITECTURE%-%version%.pkg</string>
+            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
New allowances for architecture-specific versions in the 2.0 version, as well as apparently a slightly borked new code signature?