### PR TITLE
Update MitelConnect code signature

### DIFF
--- a/Mitel Connect/MitelConnect.download.recipe
+++ b/Mitel Connect/MitelConnect.download.recipe
@@ -43,7 +43,7 @@
                 <key>input_path</key>
                 <string>%pathname%/Mitel Connect.app</string>
                 <key>requirement</key>
-                <string>identifier "com.shoretel.manhattan" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FZKTWDUNRR</string>
+                <string>identifier "com.shoretel.manhattan" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6QJ45CE63B"</string>
             </dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Looks like Mitel re-signed with their own Dev ID instead of the old ShoreTel one.