### PR TITLE
Update Okta Verify recipe to disable bundle relocation.

### DIFF
--- a/Okta Verify/OktaVerify.pkg.recipe
+++ b/Okta Verify/OktaVerify.pkg.recipe
@@ -1,84 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-    <key>Description</key>
-    <string>Download Okta Verify and copy to versioned package.</string>
-    <key>Identifier</key>
-    <string>com.github.nstrauss.pkg.OktaVerify</string>
-    <key>Input</key>
     <dict>
-        <key>NAME</key>
-        <string>OktaVerify</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>1.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.nstrauss.download.OktaVerify</string>
-    <key>Process</key>
-    <array>
+        <key>Description</key>
+        <string>Download Okta Verify and copy to versioned package.</string>
+        <key>Identifier</key>
+        <string>com.github.nstrauss.pkg.OktaVerify</string>
+        <key>Input</key>
         <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>flat_pkg_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-            <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
+            <key>NAME</key>
+            <string>OktaVerify</string>
         </dict>
-        <dict>
-            <key>Arguments</key>
+        <key>MinimumVersion</key>
+        <string>1.0</string>
+        <key>ParentRecipe</key>
+        <string>com.github.nstrauss.download.OktaVerify</string>
+        <key>Process</key>
+        <array>
             <dict>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Applications</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Applications/Okta Verify.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>info_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Applications/Okta Verify.app/Contents/Info.plist</string>
-                <key>plist_keys</key>
+                <key>Arguments</key>
                 <dict>
-                    <key>CFBundleVersion</key>
-                    <string>ov_build</string>
+                    <key>flat_pkg_path</key>
+                    <string>%pathname%</string>
+                    <key>destination_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <key>purge_destination</key>
+                    <true/>
                 </dict>
+                <key>Processor</key>
+                <string>FlatPkgUnpacker</string>
             </dict>
-            <key>Processor</key>
-            <string>PlistReader</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
             <dict>
-                <key>source_pkg</key>
-                <string>%pathname%</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.%ov_build%.pkg</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>pkg_payload_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
+                    <key>destination_path</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/Applications</string>
+                    <key>purge_destination</key>
+                    <true/>
+                </dict>
+                <key>Processor</key>
+                <string>PkgPayloadUnpacker</string>
             </dict>
-            <key>Processor</key>
-            <string>PkgCopier</string>
-        </dict>
-    </array>
-</dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>input_plist_path</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/Applications/Okta Verify.app/Contents/Info.plist</string>
+                    <key>plist_version_key</key>
+                    <string>CFBundleShortVersionString</string>
+                </dict>
+                <key>Processor</key>
+                <string>Versioner</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>info_path</key>
+                    <string>%RECIPE_CACHE_DIR%/payload/Applications/Okta Verify.app/Contents/Info.plist</string>
+                    <key>plist_keys</key>
+                    <dict>
+                        <key>CFBundleVersion</key>
+                        <string>ov_build</string>
+                    </dict>
+                </dict>
+                <key>Processor</key>
+                <string>PlistReader</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>xml_file</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack/PackageInfo</string>
+                    <key>actions</key>
+                    <array>
+                        <dict>
+                            <key>action</key>
+                            <string>remove</string>
+                            <key>xpath</key>
+                            <string>relocate</string>
+                        </dict>
+                    </array>
+                </dict>
+                <key>Processor</key>
+                <string>com.github.ccaviness.processors/XMLModifier</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>source_flatpkg_dir</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <key>destination_pkg</key>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                </dict>
+                <key>Processor</key>
+                <string>FlatPkgPacker</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>source_pkg</key>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+                    <key>pkg_path</key>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.%ov_build%.pkg</string>
+                </dict>
+                <key>Processor</key>
+                <string>PkgCopier</string>
+            </dict>
+        </array>
+    </dict>
 </plist>


### PR DESCRIPTION
To do this, modify the `PackageInfo` in the unpacked flat pkg and remove the `<relocate>` element. Then, re-pack the pkg.

This uses the `com.github.ccaviness.processors/XMLModifier` processor to make the change.