### PR TITLE
Update NWEA Secure Testing Browser download URL

### DIFF
--- a/NWEA Secure Testing Browser/NWEASecureTestingBrowser.download.recipe
+++ b/NWEA Secure Testing Browser/NWEASecureTestingBrowser.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>NWEASecureTestingBrowser</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://teach.mapnwea.org/contents/partner/Lockdown%20Browser.dmg</string>
+        <string>https://cdn.nwea.org/docs/NWEA-Secure-Testing-Browser-Mac.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
@@ -31,6 +31,17 @@
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/NWEA Secure Testing Browser.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "org.nwea.stb.client" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SRTXZJ7SQ3)</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
     </array>
 </dict>

--- a/NWEA Secure Testing Browser/NWEASecureTestingBrowser.pkg.recipe
+++ b/NWEA Secure Testing Browser/NWEASecureTestingBrowser.pkg.recipe
@@ -16,67 +16,22 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>AppDmgVersioner</string>
             <key>Arguments</key>
             <dict>
                 <key>dmg_path</key>
                 <string>%pathname%</string>
             </dict>
+            <key>Processor</key>
+            <string>AppDmgVersioner</string>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
             </dict>
-        </dict>
-        <dict>
             <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%pathname%/%app_name%</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/%app_name%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                    <key>id</key>
-                    <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
+            <string>AppPkgCreator</string>
         </dict>
     </array>
 </dict>

--- a/NWEA Secure Testing Browser/NWEASecureTestingBrowser.pkg.recipe
+++ b/NWEA Secure Testing Browser/NWEASecureTestingBrowser.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads latest NWEA Secure Testing Browser disk image and builds a package.</string>
+    <string>Downloads latest NWEA Secure Testing Browser disk image and builds a versioned package.</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.pkg.NWEASecureTestingBrowser</string>
     <key>Input</key>


### PR DESCRIPTION
- Resolves https://github.com/autopkg/nstrauss-recipes/issues/85
- Add code signature verification
- Move package recipe to `AppPkgCreator` to cut simplify steps 

