### PR TITLE
Clean up unpack and payload directories after use.

### DIFF
--- a/Okta Verify/OktaVerify.munki.recipe
+++ b/Okta Verify/OktaVerify.munki.recipe
@@ -71,6 +71,18 @@ exit 0
             <string>MunkiInstallsItemsCreator</string>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>


### PR DESCRIPTION
This removes the unpack and payload directories after use. I added this in my local override where I worked around the relocation issue and thought perhaps you'd want it as well. I will not feel bad if you prefer to keep them around and reject this PR.