### PR TITLE
Deprecate Vendini Box Office and TicketAgent recipes

### DIFF
--- a/Vendini Box Office/VendiniBoxOffice.download.recipe
+++ b/Vendini Box Office/VendiniBoxOffice.download.recipe
@@ -14,9 +14,18 @@
         <string>https://download.vendini.com/boxoffice/BoxOffice.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Vendini Box Office is no longer publicly downloadable. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/Vendini TicketAgent/VendiniTicketAgent.download.recipe
+++ b/Vendini TicketAgent/VendiniTicketAgent.download.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Vendini TicketAgent is no longer publicly downloadable. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates Vendini Box Office and TicketAgent recipes, as the software is no longer publicly downloadable.
