### PR TITLE
Deprecate ThePack recipes

### DIFF
--- a/The Pack/ThePack.download.recipe
+++ b/The Pack/ThePack.download.recipe
@@ -18,6 +18,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>The Pack is no longer available outside the Mac App Store (https://apps.apple.com/us/app/the-pack-nysci/id1458895087). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>url</key>


### PR DESCRIPTION
This PR deprecates The Pack recipes, as the software is now only available on the Mac App Store.
