### PR TITLE
Remove empty `expected_authority_names` array in CodeSignatureVerifier arguments

### DIFF
--- a/1Password/1Password.download.recipe
+++ b/1Password/1Password.download.recipe
@@ -55,8 +55,6 @@ DOWNLOAD_BUILD
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/1Password.app</string>
                 <key>requirement</key>


### PR DESCRIPTION
As long as there is a valid `requirements` argument, the `expected_authority_names` argument is not needed for code signature verification. This pull request removes the unnecessary empty `expected_authority_names` array.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.