### PR TITLE
Fix for install loop for Homebrew Munki recipe

### DIFF
--- a/Homebrew/Homebrew.munki.recipe.yaml
+++ b/Homebrew/Homebrew.munki.recipe.yaml
@@ -36,8 +36,7 @@ Process:
 
           # optionally define an install user at /var/tmp/.homebrew_pkg_user.plist
           homebrew_pkg_user_plist="/var/tmp/.homebrew_pkg_user.plist"
-          if [[ -f "${homebrew_pkg_user_plist}" ]] && [[ -n $(defaults read "${homebrew_pkg_user_plist}" HOMEBREW_PKG_USER) ]]
-          then
+          if [[ -f "${homebrew_pkg_user_plist}" ]] && [[ -n $(defaults read "${homebrew_pkg_user_plist}" HOMEBREW_PKG_USER) ]]; then
             homebrew_pkg_user=$(defaults read /var/tmp/.homebrew_pkg_user HOMEBREW_PKG_USER)
           # otherwise, get valid logged in user
           else
@@ -45,9 +44,8 @@ Process:
           fi
 
           non_users=(_mbsetupuser loginwindow root)
-          if [[ ${non_users[(r)$homebrew_pkg_user]} == $homebrew_pkg_user ]]
-          then
-            /bin/echo "No user account is logged in, so considering \"installed\" for now."
+          if [[ ${non_users[(r)$homebrew_pkg_user]} == "$homebrew_pkg_user" ]]; then
+            /bin/echo "No valid Homebrew package user available or at the login window. Considering \"installed\" for now."
             exit "$installed"
           fi
 
@@ -63,8 +61,7 @@ Process:
           fi
 
           current_version=$(/usr/bin/su -l $homebrew_pkg_user -c "$brew --version" | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }')
-
-          if  is-at-least "$target_version" "$current_version"; then
+          if is-at-least "$target_version" "$current_version"; then
             /bin/echo "$current_version is greater than or equal to $target_version"
             exit "$installed"
           else

--- a/Homebrew/Homebrew.munki.recipe.yaml
+++ b/Homebrew/Homebrew.munki.recipe.yaml
@@ -56,16 +56,16 @@ Process:
           fi
 
           if [[ ! -f "$brew" ]]; then
-            /bin/echo "$brew doesn't exist."
+            /bin/echo "$brew doesn't exist. Not installed."
             exit "$not_installed"
           fi
 
           current_version=$(/usr/bin/su -l $homebrew_pkg_user -c "$brew --version" | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }')
           if is-at-least "$target_version" "$current_version"; then
-            /bin/echo "$current_version is greater than or equal to $target_version"
+            /bin/echo "$current_version is greater than or equal to $target_version. Already installed."
             exit "$installed"
           else
-            /bin/echo "$current_version isn't at least $target_version."
+            /bin/echo "$current_version isn't at least $target_version. Not installed."
             exit "$not_installed"
           fi
 

--- a/Homebrew/Homebrew.munki.recipe.yaml
+++ b/Homebrew/Homebrew.munki.recipe.yaml
@@ -44,6 +44,13 @@ Process:
             homebrew_pkg_user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }')
           fi
 
+          non_users=(_mbsetupuser loginwindow root)
+          if [[ ${non_users[(r)$homebrew_pkg_user]} == $homebrew_pkg_user ]]
+          then
+            /bin/echo "No user account is logged in, so considering \"installed\" for now."
+            exit "$installed"
+          fi
+
           if [[ $(uname -m) == "x86_64" ]]; then
             brew="/usr/local/Homebrew/bin/brew"
           else

--- a/Homebrew/Homebrew.munki.recipe.yaml
+++ b/Homebrew/Homebrew.munki.recipe.yaml
@@ -28,6 +28,8 @@ Process:
         installcheck_script: |
           #!/bin/zsh
 
+          autoload is-at-least
+
           installed=1
           not_installed=0
           target_version="%version%"
@@ -54,11 +56,11 @@ Process:
 
           current_version=$(/usr/bin/su -l $current_user -c "$brew --version" | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }')
 
-          if [[ "$current_version" == "$target_version" ]]; then
-            /bin/echo "$target_version is installed."
+          if  is-at-least "$target_version" "$current_version"; then
+            /bin/echo "$current_version is greater than or equal to $target_version"
             exit "$installed"
           else
-            /bin/echo "$current_version isn't $target_version."
+            /bin/echo "$current_version isn't at least $target_version."
             exit "$not_installed"
           fi
 

--- a/Homebrew/Homebrew.munki.recipe.yaml
+++ b/Homebrew/Homebrew.munki.recipe.yaml
@@ -34,13 +34,14 @@ Process:
           not_installed=0
           target_version="%version%"
 
-          # Get the current user
-          current_user="$(/usr/bin/stat -f%Su /dev/console)"
-
-          # If we're at the login window, Homebrew's .pkg will fail to install
-          if [[ $current_user == "root" || $current_user == "_mbsetupuser" || $current_user == "loginwindow" ]]; then
-            /bin/echo "No user account is logged in, so considering \"installed\" for now."
-            exit "$installed"
+          # optionally define an install user at /var/tmp/.homebrew_pkg_user.plist
+          homebrew_pkg_user_plist="/var/tmp/.homebrew_pkg_user.plist"
+          if [[ -f "${homebrew_pkg_user_plist}" ]] && [[ -n $(defaults read "${homebrew_pkg_user_plist}" HOMEBREW_PKG_USER) ]]
+          then
+            homebrew_pkg_user=$(defaults read /var/tmp/.homebrew_pkg_user HOMEBREW_PKG_USER)
+          # otherwise, get valid logged in user
+          else
+            homebrew_pkg_user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }')
           fi
 
           if [[ $(uname -m) == "x86_64" ]]; then
@@ -54,7 +55,7 @@ Process:
             exit "$not_installed"
           fi
 
-          current_version=$(/usr/bin/su -l $current_user -c "$brew --version" | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }')
+          current_version=$(/usr/bin/su -l $homebrew_pkg_user -c "$brew --version" | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }')
 
           if  is-at-least "$target_version" "$current_version"; then
             /bin/echo "$current_version is greater than or equal to $target_version"

--- a/Homebrew/Homebrew.munki.recipe.yaml
+++ b/Homebrew/Homebrew.munki.recipe.yaml
@@ -32,6 +32,15 @@ Process:
           not_installed=0
           target_version="%version%"
 
+          # Get the current user
+          current_user="$(/usr/bin/stat -f%Su /dev/console)"
+
+          # If we're at the login window, Homebrew's .pkg will fail to install
+          if [[ $current_user == "root" || $current_user == "_mbsetupuser" || $current_user == "loginwindow" ]]; then
+            /bin/echo "No user account is logged in, so considering \"installed\" for now."
+            exit "$installed"
+          fi
+
           if [[ $(uname -m) == "x86_64" ]]; then
             brew="/usr/local/Homebrew/bin/brew"
           else
@@ -39,17 +48,18 @@ Process:
           fi
 
           if [[ ! -f "$brew" ]]; then
+            /bin/echo "$brew doesn't exist."
             exit "$not_installed"
           fi
 
-          current_version=$($brew --version | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }')
+          current_version=$(/usr/bin/su -l $current_user -c "$brew --version" | /usr/bin/head -n 1 | /usr/bin/awk '{ print $2 }')
 
-          if [[ "$current_version" != "$target_version" ]]; then
-              exit "$not_installed"
-          elif [[ "$current_version" == "$target_version" ]]; then
-              exit "$installed"
+          if [[ "$current_version" == "$target_version" ]]; then
+            /bin/echo "$target_version is installed."
+            exit "$installed"
           else
-              exit "$not_installed"
+            /bin/echo "$current_version isn't $target_version."
+            exit "$not_installed"
           fi
 
   - Processor: MunkiImporter


### PR DESCRIPTION
## Issue addressed
https://github.com/autopkg/nstrauss-recipes/issues/92

## Details of PR
- Checks to see if a user account is logged in. [The brew .pkg's preinstall script will fail if no user account is logged in](https://github.com/Homebrew/brew/blob/4ee6e96bdf857b3c50290bf032a9645b3bf293f1/package/scripts/preinstall#L13), which would result in an install loop at the login window.
- Adds debug output for the /Library/Managed Installs/Logs/ManagedSoftwareupdate.log
- Runs the `brew --version` command as the logged in user, as it fails to run properly as root
- Compressed if/then/else to if/else for version comparison
- Leverages [is-at-least](https://scriptingosx.com/2019/11/comparing-version-strings-in-zsh/) so that Munki won't _downgrade_ `brew` if users update `brew` before the next AutoPkg run