### PR TITLE
Update recipes to account for Fusion 360 to Fusion transition

### DIFF
--- a/Autodesk Fusion/AutodeskFusion360.download.recipe
+++ b/Autodesk Fusion/AutodeskFusion360.download.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Autodesk Fusion 360 for Education.</string>
+    <string>Downloads the latest version of Autodesk Fusion.</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.download.AutodeskFusion360</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>Autodesk Fusion 360</string>
+        <string>Autodesk Fusion</string>
         <key>DOWNLOAD_URL</key>
         <string>https://dl.appstreaming.autodesk.com/production/installers/Autodesk%20Fusion%20Admin%20Install.pkg</string>
     </dict>
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>AutodeskFusion360.pkg</string>
+                <string>AutodeskFusion.pkg</string>
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
             </dict>

--- a/Autodesk Fusion/AutodeskFusion360.install.recipe
+++ b/Autodesk Fusion/AutodeskFusion360.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads and installs the latest version of Autodesk Fusion 360 for Education.</string>
+    <string>Downloads the latest version of Autodesk Fusion, creates a versioned package, and installs it.</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.install.AutodeskFusion360</string>
     <key>Input</key>

--- a/Autodesk Fusion/AutodeskFusion360.pkg.recipe
+++ b/Autodesk Fusion/AutodeskFusion360.pkg.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Autodesk Fusion 360 for Education and creates package.</string>
+    <string>Downloads the latest version of Autodesk Fusion and creates a versioned package.</string>
     <key>Identifier</key>
     <string>com.github.nstrauss.pkg.AutodeskFusion360</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>Autodesk Fusion 360</string>
+        <string>Autodesk Fusion</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Autodesk Fusion 360.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/payload/%NAME%.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>
@@ -58,7 +58,7 @@
                 <key>source_pkg</key>
                 <string>%pathname%</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/AutodeskFusion360-%version%.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/AutodeskFusion-%version%.pkg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Fixes https://github.com/autopkg/nstrauss-recipes/issues/99

The recipe names and identifiers are staying as is for now to not introduce breaking changes. Will need to eventually rename them entirely. 