### PR TITLE
VirusTotalReporter fix for `Error: 'str' object cannot be interpreted as an integer`

### DIFF
--- a/VirusTotalReporter/VirusTotalReporter.py
+++ b/VirusTotalReporter/VirusTotalReporter.py
@@ -342,7 +342,7 @@ class VirusTotalReporter(Processor):
                     )
                     url_identifier = self.get_base64_unpadded(download_url)
                     report, report_status_code = self.virustotal_api_v3(
-                        f"/urls/{url_identifier}", None, self.env["submission_timeout"]
+                        f"/urls/{url_identifier}", None, int(self.env.get("submission_timeout"))
                     )
 
                     if report_status_code == 200:


### PR DESCRIPTION
Extends #80 to the other use of `submission_timeout`, specifically for when the input variable is set on the command line.