### PR TITLE
Remove dialog bin from installs item path

### DIFF
--- a/swiftDialog/swiftDialog.munki.recipe
+++ b/swiftDialog/swiftDialog.munki.recipe
@@ -36,6 +36,9 @@
                 <string>%DISPLAY_NAME%</string>
                 <key>name</key>
                 <string>%MUNKI_NAME%</string>
+                <key>postuninstall_script</key>
+                <string>#!/bin/zsh
+rm -rf /usr/local/bin/dialog</string>
                 <key>unattended_install</key>
                 <true/>
                 <key>unattended_uninstall</key>

--- a/swiftDialog/swiftDialog.munki.recipe
+++ b/swiftDialog/swiftDialog.munki.recipe
@@ -76,7 +76,6 @@
                     <key>installs_item_paths</key>
                     <array>
                         <string>/Library/Application Support/Dialog/Dialog.app</string>
-                        <string>/usr/local/bin/dialog</string>
                     </array>
                 </dict>
                 <key>Processor</key>


### PR DESCRIPTION
Removes `/usr/local/bin/dialog` from the installs array.
Since SwiftDialog 3, `/usr/local/bin/dialog` is a symlink created during `postinstall`. Adding this to the installs array now creates an install loop, as the hash added in the Munki pkgsinfo is now always incorrect. 

This PR fixes this issue going forward. Personally, I think it is better to not keep track of an installs item, and handle it with the `postuninstall_script`, if we cannot ascertain the hash of the file upon creating the install items array.